### PR TITLE
Prevent deletion of multiple items in one go

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ to delete a created note.
 Key features of the app
 
 -Use ctrl + Plus/Minus to easily navigate between textboxes and todos.
--Backspace can also be used on an emtpy note or todo to remove it.
+-Alt + shift + backspace can be used to immediately delete a note/todo, even if it still contains text.
 -You can also create a note or todo without even moving your mouse! Simply
 type /note or /todo into text box and newly created entry will appear.
 

--- a/ToNote/Controls/ExtendedRichTextBox.cs
+++ b/ToNote/Controls/ExtendedRichTextBox.cs
@@ -13,17 +13,12 @@
     {
         public ExtendedRichTextBox()
         {
-            // Checks if backspace was pressed when the textbox was empty and raises an event. Used for convenient empty textbox removal
             this.PreviewKeyDown += (s, e) =>
             {
-                if (e.Key == Key.Back)
+                if ((e.Key == Key.System ? e.SystemKey : e.Key) == Key.Back && Keyboard.Modifiers == (ModifierKeys.Alt | ModifierKeys.Shift))
                 {
-                    var range = new TextRange(Document.ContentStart, Document.ContentEnd);
-                    if (string.IsNullOrWhiteSpace(range.Text))
-                    {
-                        BackspacePressedWhileEmpty?.Invoke(this, new RoutedEventArgs());
-                        e.Handled = true;
-                    }
+                    BackspacePressedWithAltShiftModifiers?.Invoke(this, new RoutedEventArgs());
+                    e.Handled = true;
                 }
             };
 
@@ -85,7 +80,7 @@
             };
         }
 
-        public event RoutedEventHandler BackspacePressedWhileEmpty;
+        public event RoutedEventHandler BackspacePressedWithAltShiftModifiers;
 
         public TextPointer CommandExecutionPointer;
 

--- a/ToNote/Controls/NotePanel.cs
+++ b/ToNote/Controls/NotePanel.cs
@@ -200,7 +200,7 @@
         /// <param name="extendedTextBoxControl"></param>
         private void ConfigureExtendedTextBoxControlEvents(IExtendedTextBoxControl extendedTextBoxControl)
         {
-            extendedTextBoxControl.BackspacePressedWhileEmpty += (s, e) =>
+            extendedTextBoxControl.BackspacePressedWithAltShiftModifiers += (s, e) =>
             {
                 var index = this.Items.IndexOf(lastFocused);
 

--- a/ToNote/Controls/TodoControl.cs
+++ b/ToNote/Controls/TodoControl.cs
@@ -31,16 +31,16 @@
                 extendedRTB = rtb;
 
                 //If an ExtendedRichTextBox is found, hooks to the BackspacePressedWhileEmpty event.
-                rtb.BackspacePressedWhileEmpty += (o, a) =>
+                rtb.BackspacePressedWithAltShiftModifiers += (o, a) =>
                 {
-                    this.BackspacePressedWhileEmpty?.Invoke(this, new RoutedEventArgs());
+                    this.BackspacePressedWithAltShiftModifiers?.Invoke(this, new RoutedEventArgs());
                 };
             };
         }
 
         public Todo Todo { get; private set; }
 
-        public event RoutedEventHandler BackspacePressedWhileEmpty;
+        public event RoutedEventHandler BackspacePressedWithAltShiftModifiers;
 
         private ExtendedRichTextBox extendedRTB;
 

--- a/ToNote/Interfaces/IExtendedTextBoxControl.cs
+++ b/ToNote/Interfaces/IExtendedTextBoxControl.cs
@@ -7,7 +7,7 @@ namespace ToNote.Interfaces
 {
     public interface IExtendedTextBoxControl
     {
-        event RoutedEventHandler BackspacePressedWhileEmpty;
+        event RoutedEventHandler BackspacePressedWithAltShiftModifiers;
         event KeyboardFocusChangedEventHandler GotKeyboardFocus;
 
         TextRange TextRange { get; }


### PR DESCRIPTION
Changed the key combo to remove a note item to alt+shift+back, removed requirement for the textbox to be empty.