### PR TITLE
Fixed: Note name validation

### DIFF
--- a/ToNote/ViewModels/AddNoteDialogViewModel.cs
+++ b/ToNote/ViewModels/AddNoteDialogViewModel.cs
@@ -88,7 +88,7 @@
                         else if (Name.IndexOfAny(forbiddenChars) != -1)
                         {
                             ErrorVisible = true;
-                            ErrorMessage = "Note name cannot contain any of \\ / : &lt; &gt; &#34; &#42; ? | characters";
+                            ErrorMessage = "Note name cannot contain any of \\ / : * \" < > ? | characters";
                         }
                         else
                             CloseDialogWithResult(window, new Note(Name));

--- a/ToNote/ViewModels/AddNoteDialogViewModel.cs
+++ b/ToNote/ViewModels/AddNoteDialogViewModel.cs
@@ -36,6 +36,22 @@
             }
         }
 
+        private string _ErrorMessage;
+
+        public string ErrorMessage
+        {
+            get => _ErrorMessage;
+            set
+            {
+                if (_ErrorMessage != value)
+                {
+                    _ErrorMessage = value;
+
+                    RaisePropertyChanged(nameof(ErrorMessage));
+                }
+            }
+        }
+
         private bool _ErrorVisible;
 
         public bool ErrorVisible
@@ -64,12 +80,20 @@
                     {
                         var forbiddenChars = "\\/:?<>|*\"".ToCharArray();
 
-                        if (Notes.Any(x => x.Name.Equals(Name)))
-                            MessageBox.Show("Name already taken.", "Name taken", MessageBoxButton.OK, MessageBoxImage.Exclamation);
-                        else if (Name.IndexOfAny(forbiddenChars) != -1)
+                        if (Notes.Any(x => x.Name.ToLower().Equals(Name.ToLower())))
+                        {
                             ErrorVisible = true;
+                            ErrorMessage = "Name already taken.";
+                        }
+                        else if (Name.IndexOfAny(forbiddenChars) != -1)
+                        {
+                            ErrorVisible = true;
+                            ErrorMessage = "Note name cannot contain any of \\ / : &lt; &gt; &#34; &#42; ? | characters";
+                        }
                         else
                             CloseDialogWithResult(window, new Note(Name));
+
+                        
                     }
                 }));
             }

--- a/ToNote/ViewModels/AddNoteDialogViewModel.cs
+++ b/ToNote/ViewModels/AddNoteDialogViewModel.cs
@@ -1,5 +1,8 @@
 ﻿namespace ToNote.ViewModels
 {
+    using System.Collections.ObjectModel;
+    using System.Linq;
+    using System.Windows;
     using System.Windows.Input;
     using ToNote.Interfaces;
     using ToNote.Logic;
@@ -11,6 +14,8 @@
         {
 
         }
+
+        public Collection<Note> Notes { get; set; } = new Collection<Note>();
 
         private string _Name;
 
@@ -31,6 +36,22 @@
             }
         }
 
+        private bool _ErrorVisible;
+
+        public bool ErrorVisible
+        {
+            get => _ErrorVisible;
+            set
+            {
+                if (_ErrorVisible != value)
+                {
+                    _ErrorVisible = value;
+
+                    RaisePropertyChanged(nameof(ErrorVisible));
+                }
+            }
+        }
+
         private ICommand _AddNoteCommand;
 
         public ICommand AddNoteCommand
@@ -41,7 +62,14 @@
                 {
                     if (!string.IsNullOrWhiteSpace(Name))
                     {
-                        CloseDialogWithResult(window, new Note(Name));
+                        var forbiddenChars = "\\/:?<>|".ToCharArray();
+
+                        if (Notes.Any(x => x.Name.Equals(Name)))
+                            MessageBox.Show("Name already taken.", "Name taken", MessageBoxButton.OK, MessageBoxImage.Exclamation);
+                        else if (Name.IndexOfAny(forbiddenChars) != -1)
+                            ErrorVisible = true;
+                        else
+                            CloseDialogWithResult(window, new Note(Name));
                     }
                 }));
             }

--- a/ToNote/ViewModels/AddNoteDialogViewModel.cs
+++ b/ToNote/ViewModels/AddNoteDialogViewModel.cs
@@ -62,7 +62,7 @@
                 {
                     if (!string.IsNullOrWhiteSpace(Name))
                     {
-                        var forbiddenChars = "\\/:?<>|".ToCharArray();
+                        var forbiddenChars = "\\/:?<>|*\"".ToCharArray();
 
                         if (Notes.Any(x => x.Name.Equals(Name)))
                             MessageBox.Show("Name already taken.", "Name taken", MessageBoxButton.OK, MessageBoxImage.Exclamation);

--- a/ToNote/ViewModels/MainViewModel.cs
+++ b/ToNote/ViewModels/MainViewModel.cs
@@ -60,15 +60,12 @@
                     var dialog = new AddNoteDialogViewModel();
                     dialog.Resizeable = false;
                     dialog.Title = "Add a note";
+                    dialog.Notes = Notes;
 
                     var result = DialogService.OpenDialog(dialog);
 
-                    var forbiddenChars = "\\/:?<>|".ToCharArray();
-
-                    if (result.Name.IndexOfAny(forbiddenChars) == -1 && result != null && !Notes.Any(x => x.Name.Equals(result.Name)))
+                    if (result != null)
                         Notes.Add(result);
-                    else if (result.Name.IndexOfAny(forbiddenChars) != -1)
-                        MessageBox.Show("Note name cannot contain any of \\ / : ? < > | characters");
                 }));
             }
         }

--- a/ToNote/ViewModels/MainViewModel.cs
+++ b/ToNote/ViewModels/MainViewModel.cs
@@ -63,8 +63,12 @@
 
                     var result = DialogService.OpenDialog(dialog);
 
-                    if (result != null && !Notes.Any(x => x.Name.Equals(result.Name)))
+                    var forbiddenChars = "\\/:?<>|".ToCharArray();
+
+                    if (result.Name.IndexOfAny(forbiddenChars) == -1 && result != null && !Notes.Any(x => x.Name.Equals(result.Name)))
                         Notes.Add(result);
+                    else if (result.Name.IndexOfAny(forbiddenChars) != -1)
+                        MessageBox.Show("Note name cannot contain any of \\ / : ? < > | characters");
                 }));
             }
         }

--- a/ToNote/Views/AddNoteDialogView.xaml
+++ b/ToNote/Views/AddNoteDialogView.xaml
@@ -21,6 +21,6 @@
             </TextBox.InputBindings>
         </TextBox>
         <Button Command="{Binding AddNoteCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}" Content="Add" Grid.Column="2"/>
-        <TextBlock Text="Note name cannot contain any of \ / : &lt; &gt; ? | characters" HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="10" Foreground="Red" Margin="5,0,0,45" Grid.Column="1" Height="15" Width="225"/>
+        <TextBlock Visibility="{Binding ErrorVisible, Converter={StaticResource BoolToVisibilityConverter}}" Text="Note name cannot contain any of \ / : &lt; &gt; ? | characters" HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="10" Foreground="Red" Margin="5,0,0,45" Grid.Column="1" Height="15" Width="225"/>
     </Grid>
 </UserControl>

--- a/ToNote/Views/AddNoteDialogView.xaml
+++ b/ToNote/Views/AddNoteDialogView.xaml
@@ -21,6 +21,6 @@
             </TextBox.InputBindings>
         </TextBox>
         <Button Command="{Binding AddNoteCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}" Content="Add" Grid.Column="2"/>
-        <TextBlock Visibility="{Binding ErrorVisible, Converter={StaticResource BoolToVisibilityConverter}}" Text="Note name cannot contain any of \ / : &lt; &gt; ? | characters" HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="10" Foreground="Red" Margin="5,0,0,45" Grid.Column="1" Height="15" Width="225"/>
+        <TextBlock Visibility="{Binding ErrorVisible, Converter={StaticResource BoolToVisibilityConverter}}" Text="Note name cannot contain any of \ / : &lt; &gt; &#34; &#42; ? | characters" HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="10" Foreground="Red" Margin="5,0,0,45" Grid.Column="1" Height="15" Width="225"/>
     </Grid>
 </UserControl>

--- a/ToNote/Views/AddNoteDialogView.xaml
+++ b/ToNote/Views/AddNoteDialogView.xaml
@@ -21,5 +21,6 @@
             </TextBox.InputBindings>
         </TextBox>
         <Button Command="{Binding AddNoteCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}" Content="Add" Grid.Column="2"/>
+        <TextBlock Text="Note name cannot contain any of \ / : &lt; &gt; ? | characters" HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="10" Foreground="Red" Margin="5,0,0,45" Grid.Column="1" Height="15" Width="225"/>
     </Grid>
 </UserControl>

--- a/ToNote/Views/AddNoteDialogView.xaml
+++ b/ToNote/Views/AddNoteDialogView.xaml
@@ -21,7 +21,7 @@
             </TextBox.InputBindings>
         </TextBox>
         <Button Command="{Binding AddNoteCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}" Content="Add" Grid.Column="2"/>
-        <TextBlock Visibility="{Binding ErrorVisible, Converter={StaticResource BoolToVisibilityConverter}}" Text="{Binding ErrorMessage}" HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="10" Foreground="Red" Margin="5,0,0,45" Grid.Column="1" Height="15" Width="225"/>
+        <TextBlock Visibility="{Binding ErrorVisible, Converter={StaticResource BoolToVisibilityConverter}}" Text="{Binding ErrorMessage}" HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="10" Foreground="Red" Margin="5,0,0,45" Grid.Column="1" Height="15" Width="250"/>
   
     </Grid>
 </UserControl>

--- a/ToNote/Views/AddNoteDialogView.xaml
+++ b/ToNote/Views/AddNoteDialogView.xaml
@@ -21,6 +21,7 @@
             </TextBox.InputBindings>
         </TextBox>
         <Button Command="{Binding AddNoteCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}" Content="Add" Grid.Column="2"/>
-        <TextBlock Visibility="{Binding ErrorVisible, Converter={StaticResource BoolToVisibilityConverter}}" Text="Note name cannot contain any of \ / : &lt; &gt; &#34; &#42; ? | characters" HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="10" Foreground="Red" Margin="5,0,0,45" Grid.Column="1" Height="15" Width="225"/>
+        <TextBlock Visibility="{Binding ErrorVisible, Converter={StaticResource BoolToVisibilityConverter}}" Text="{Binding ErrorMessage}" HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="10" Foreground="Red" Margin="5,0,0,45" Grid.Column="1" Height="15" Width="225"/>
+  
     </Grid>
 </UserControl>


### PR DESCRIPTION
Note names as folders cannot contain any of the following chars - "? : < > | \ /".
Added a small warning above note creation textbox about these chars. Wanted to make it only visible when user enters wrong chars, but a man has to sleep.
Also added a message pop up to warn user that his note name is not allowed.